### PR TITLE
Make it a "must-use" plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "phpwatch/wordpress-fast404",
     "description": "WordPress plugin to prevent WordPress from deliverying full Page-Not-Found errors when the browser is not expecting a full HTML page. Saves bandwidth and improves performance.",
-    "type": "wordpress-plugin",
+    "type": "wordpress-muplugin",
     "license": "GPL-2.0-or-later",
     "keywords": ["wordpress", "performance", "404"],
     "homepage": "https://wordpress.org/plugins/fast404/",


### PR DESCRIPTION
The composer version of this plugin (as relied on by Bedrock) is more of a "mu-plugin" than a plugin.
Only an admin running `composer` would consider the composer.json file, there is no UI, configuration is based on `define`.

As such, it seems that a mu-plugins is better suited.